### PR TITLE
feat: add NIC configurations to backend pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following resources are used by this module:
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
+- [azurerm_network_interface_backend_address_pool_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_backend_address_pool_association) (resource)
 - [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) (resource)
 - [azurerm_resource_group_template_deployment.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group_template_deployment) (resource)
 - [azurerm_role_assignment.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
@@ -215,11 +216,42 @@ Default: `{}`
 
 ### <a name="input_backend_address_pool_configuration"></a> [backend\_address\_pool\_configuration](#input\_backend\_address\_pool\_configuration)
 
-Description:   String variable that determines the target virtual network for potential backend pools.
+Description:   String variable that determines the target virtual network for potential backend pools.  
+  If using network interfaces, leave this variable empty.
 
 Type: `string`
 
 Default: `null`
+
+### <a name="input_backend_address_pool_network_interfaces"></a> [backend\_address\_pool\_network\_interfaces](#input\_backend\_address\_pool\_network\_interfaces)
+
+Description:   A map of objects that associates one or more backend address pool network interfaces
+
+  - `backend_address_pool_object_name`: (Optional) The name of the backend address pool object that this network interface should be associated with
+  - `ip_configuration_name`: (Optional) The name of the IP configuration that this network interface should be associated with
+  - `network_interface_resource_id`: (Optional) The ID of the network interface that should be associated with the backend address pool
+
+  ```terraform
+  backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}"
+      ip_configuration_name = "ipconfig1"
+      network_interface_resource_id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
+    }
+  }
+```
+
+Type:
+
+```hcl
+map(object({
+    backend_address_pool_object_name = optional(string)
+    ip_configuration_name            = optional(string)
+    network_interface_resource_id    = optional(string)
+  }))
+```
+
+Default: `{}`
 
 ### <a name="input_backend_address_pools"></a> [backend\_address\_pools](#input\_backend\_address\_pools)
 

--- a/examples/bepool_with_ip_address/README.md
+++ b/examples/bepool_with_ip_address/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Default example
 
-This deploys the module with a backend pool configured to use NIC. (Standard SKU Public Load Balancer).
+This deploys the module with a backend pool configured to use IPs. (Standard SKU Public Load Balancer).
 
 ```hcl
 terraform {
@@ -106,7 +106,7 @@ module "loadbalancer" {
 
   # Virtual Network for Backend Address Pool(s) if using backend addresses
   # Leave empty if using network interfaces
-  # backend_address_pool_configuration = azurerm_virtual_network.example.id
+  backend_address_pool_configuration = azurerm_virtual_network.example.id
 
   # Backend Address Pool(s)
   backend_address_pools = {
@@ -116,29 +116,20 @@ module "loadbalancer" {
   }
 
   backend_address_pool_network_interfaces = {
-    node1 = {
-      backend_address_pool_object_name = "pool1"
-      ip_configuration_name            = "ipconfig1"
-      network_interface_resource_id    = azurerm_network_interface.example_1.id
-    }
-    node2 = {
-      backend_address_pool_object_name = "pool1"
-      ip_configuration_name            = "ipconfig1"
-      network_interface_resource_id    = azurerm_network_interface.example_2.id
-    }
+
   }
 
   backend_address_pool_addresses = {
-    # address1 = {
-    #   name = "${azurerm_network_interface.example.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address = azurerm_network_interface.example_1.private_ip_address
-    # }
-    # address2 = {
-    #   name = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address = azurerm_network_interface.example_2.private_ip_address
-    # }
+    address1 = {
+      name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_1.private_ip_address
+    }
+    address2 = {
+      name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_2.private_ip_address
+    }
   }
 
   # Health Probe(s)

--- a/examples/bepool_with_ip_address/README.md
+++ b/examples/bepool_with_ip_address/README.md
@@ -89,7 +89,7 @@ module "loadbalancer" {
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
   # version = 0.1.4
 
-  enable_telemetry = false # var.enable_telemetry
+  enable_telemetry = var.enable_telemetry
 
   name                = "default-lb"
   location            = azurerm_resource_group.this.location

--- a/examples/bepool_with_ip_address/README.md
+++ b/examples/bepool_with_ip_address/README.md
@@ -64,7 +64,7 @@ resource "azurerm_network_interface" "example_1" {
   resource_group_name = azurerm_resource_group.this.name
 
   ip_configuration {
-    name                          = "ipconfig1" # -${module.naming.network_interface.name_unique}"
+    name                          = "ipconfig1"
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.example.id
   }
@@ -76,7 +76,7 @@ resource "azurerm_network_interface" "example_2" {
   resource_group_name = azurerm_resource_group.this.name
 
   ip_configuration {
-    name                          = "ipconfig1" # -${module.naming.network_interface.name_unique}"
+    name                          = "ipconfig1"
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.example.id
   }
@@ -157,6 +157,12 @@ module "loadbalancer" {
       enable_tcp_reset        = true
     }
   }
+
+  depends_on = [
+    # To ensure that the backend address pool is created before the network interfaces' ip addresses are associated
+    azurerm_network_interface.example_1,
+    azurerm_network_interface.example_2
+  ]
 
 }
 ```

--- a/examples/bepool_with_ip_address/_footer.md
+++ b/examples/bepool_with_ip_address/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/bepool_with_ip_address/_header.md
+++ b/examples/bepool_with_ip_address/_header.md
@@ -1,0 +1,3 @@
+# Default example
+
+This deploys the module with a backend pool configured to use IPs. (Standard SKU Public Load Balancer).

--- a/examples/bepool_with_ip_address/locals.tf
+++ b/examples/bepool_with_ip_address/locals.tf
@@ -1,0 +1,16 @@
+# We pick a random region from this list.
+locals {
+  azure_regions = [
+    "westeurope",
+    "northeurope",
+    "eastus",
+    "eastus2",
+    "westus",
+    "westus2",
+    "southcentralus",
+    "northcentralus",
+    "centralus",
+    "eastasia",
+    "southeastasia",
+  ]
+}

--- a/examples/bepool_with_ip_address/main.tf
+++ b/examples/bepool_with_ip_address/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_network_interface" "example_1" {
   resource_group_name = azurerm_resource_group.this.name
 
   ip_configuration {
-    name                          = "ipconfig1" # -${module.naming.network_interface.name_unique}"
+    name                          = "ipconfig1"
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.example.id
   }
@@ -70,7 +70,7 @@ resource "azurerm_network_interface" "example_2" {
   resource_group_name = azurerm_resource_group.this.name
 
   ip_configuration {
-    name                          = "ipconfig1" # -${module.naming.network_interface.name_unique}"
+    name                          = "ipconfig1"
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.example.id
   }
@@ -151,5 +151,11 @@ module "loadbalancer" {
       enable_tcp_reset        = true
     }
   }
+
+  depends_on = [
+    # To ensure that the backend address pool is created before the network interfaces' ip addresses are associated
+    azurerm_network_interface.example_1,
+    azurerm_network_interface.example_2
+  ]
 
 }

--- a/examples/bepool_with_ip_address/main.tf
+++ b/examples/bepool_with_ip_address/main.tf
@@ -83,7 +83,7 @@ module "loadbalancer" {
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
   # version = 0.1.4
 
-  enable_telemetry = false # var.enable_telemetry
+  enable_telemetry = var.enable_telemetry
 
   name                = "default-lb"
   location            = azurerm_resource_group.this.location

--- a/examples/bepool_with_ip_address/main.tf
+++ b/examples/bepool_with_ip_address/main.tf
@@ -100,7 +100,7 @@ module "loadbalancer" {
 
   # Virtual Network for Backend Address Pool(s) if using backend addresses
   # Leave empty if using network interfaces
-  # backend_address_pool_configuration = azurerm_virtual_network.example.id
+  backend_address_pool_configuration = azurerm_virtual_network.example.id
 
   # Backend Address Pool(s)
   backend_address_pools = {
@@ -110,29 +110,20 @@ module "loadbalancer" {
   }
 
   backend_address_pool_network_interfaces = {
-    node1 = {
-      backend_address_pool_object_name = "pool1"
-      ip_configuration_name            = "ipconfig1"
-      network_interface_resource_id    = azurerm_network_interface.example_1.id
-    }
-    node2 = {
-      backend_address_pool_object_name = "pool1"
-      ip_configuration_name            = "ipconfig1"
-      network_interface_resource_id    = azurerm_network_interface.example_2.id
-    }
+
   }
 
   backend_address_pool_addresses = {
-    # address1 = {
-    #   name = "${azurerm_network_interface.example.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address = azurerm_network_interface.example_1.private_ip_address
-    # }
-    # address2 = {
-    #   name = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address = azurerm_network_interface.example_2.private_ip_address
-    # }
+    address1 = {
+      name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_1.private_ip_address
+    }
+    address2 = {
+      name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_2.private_ip_address
+    }
   }
 
   # Health Probe(s)

--- a/examples/bepool_with_ip_address/variables.tf
+++ b/examples/bepool_with_ip_address/variables.tf
@@ -1,0 +1,9 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}

--- a/examples/bepool_with_nic_config/README.md
+++ b/examples/bepool_with_nic_config/README.md
@@ -1,0 +1,231 @@
+<!-- BEGIN_TF_DOCS -->
+# Default example
+
+This deploys the module with a backend pool configured to use NIC. (Standard SKU Public Load Balancer).
+
+```hcl
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+  }
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.3.0"
+}
+
+# Helps pick a random region from the list of regions.
+resource "random_integer" "region_index" {
+  max = length(local.azure_regions) - 1
+  min = 0
+}
+
+# This is required for resource modules
+
+# Creates a resource group
+resource "azurerm_resource_group" "this" {
+  location = local.azure_regions[random_integer.region_index.result]
+  name     = module.naming.resource_group.name_unique
+}
+
+# Creates a virtual network
+resource "azurerm_virtual_network" "example" {
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.virtual_network.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# Creates a subnet
+resource "azurerm_subnet" "example" {
+  address_prefixes     = ["10.1.1.0/26"]
+  name                 = module.naming.subnet.name_unique
+  resource_group_name  = azurerm_virtual_network.example.resource_group_name
+  virtual_network_name = azurerm_virtual_network.example.name
+}
+
+resource "azurerm_network_interface" "example" {
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.network_interface.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "ipconfig1" # -${module.naming.network_interface.name_unique}"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
+  }
+}
+
+# data "azurerm_network_interface" "example" {
+#   name = azurerm_network_interface.example.name
+#   resource_group_name = azurerm_network_interface.example.resource_group_name
+#   depends_on = [ 
+#     azurerm_network_interface.example 
+#   ]
+# }
+
+module "loadbalancer" {
+
+  source = "../../"
+
+  # source = "Azure/avm-res-network-loadbalancer/azurerm"
+  # version = 0.1.4
+
+  enable_telemetry = false # var.enable_telemetry
+
+  name                = "default-lb"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  frontend_ip_configurations = {
+    frontend_configuration_1 = {
+      name = "myFrontend"
+      # Creates a public IP address
+      create_public_ip_address        = true
+      public_ip_address_resource_name = module.naming.public_ip.name_unique
+    }
+  }
+
+  # Virtual Network for Backend Address Pool(s) if using backend addresses
+  # Leave empty if using network interfaces
+  # backend_address_pool_configuration = azurerm_virtual_network.example.id
+
+  # Backend Address Pool(s)
+  backend_address_pools = {
+    pool1 = {
+      name = "myBackendPool"
+    }
+  }
+
+  backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "pool1"
+      ip_configuration_name            = "ipconfig1" # data.azurerm_network_interface.example.ip_configuration[0].name # Might be easier to specify the name of the ip configuration
+      network_interface_resource_id    = azurerm_network_interface.example.id
+    }
+  }
+
+  backend_address_pool_addresses = {
+    # address1 = {
+    #   name = "${azurerm_network_interface.example.name}-ipconfig1" # must be unique if multiple addresses are used
+    #   backend_address_pool_object_name = "pool1"
+    #   ip_address = azurerm_network_interface.example.private_ip_address
+    # }
+  }
+
+  # Health Probe(s)
+  lb_probes = {
+    tcp1 = {
+      name     = "myHealthProbe"
+      protocol = "Tcp"
+    }
+  }
+
+  # Load Balaner rule(s)
+  lb_rules = {
+    http1 = {
+      name                           = "myHTTPRule"
+      frontend_ip_configuration_name = "myFrontend"
+
+      backend_address_pool_object_names = ["pool1"]
+      protocol                          = "Tcp"
+      frontend_port                     = 80
+      backend_port                      = 80
+
+      probe_object_name = "tcp1"
+
+      idle_timeout_in_minutes = 15
+      enable_tcp_reset        = true
+    }
+  }
+
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (~> 1.5)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.7)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Providers
+
+The following providers are used by this module:
+
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (~> 3.7)
+
+- <a name="provider_random"></a> [random](#provider\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_network_interface.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [azurerm_subnet.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
+- [azurerm_virtual_network.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
+- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see https://aka.ms/avm/telemetryinfo.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_loadbalancer"></a> [loadbalancer](#module\_loadbalancer)
+
+Source: ../../
+
+Version:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: 0.3.0
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/bepool_with_nic_config/README.md
+++ b/examples/bepool_with_nic_config/README.md
@@ -89,7 +89,7 @@ module "loadbalancer" {
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
   # version = 0.1.4
 
-  enable_telemetry = false # var.enable_telemetry
+  enable_telemetry = var.enable_telemetry
 
   name                = "default-lb"
   location            = azurerm_resource_group.this.location

--- a/examples/bepool_with_nic_config/_footer.md
+++ b/examples/bepool_with_nic_config/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/bepool_with_nic_config/_header.md
+++ b/examples/bepool_with_nic_config/_header.md
@@ -1,0 +1,3 @@
+# Default example
+
+This deploys the module with a backend pool configured to use NIC. (Standard SKU Public Load Balancer).

--- a/examples/bepool_with_nic_config/locals.tf
+++ b/examples/bepool_with_nic_config/locals.tf
@@ -1,0 +1,16 @@
+# We pick a random region from this list.
+locals {
+  azure_regions = [
+    "westeurope",
+    "northeurope",
+    "eastus",
+    "eastus2",
+    "westus",
+    "westus2",
+    "southcentralus",
+    "northcentralus",
+    "centralus",
+    "eastasia",
+    "southeastasia",
+  ]
+}

--- a/examples/bepool_with_nic_config/main.tf
+++ b/examples/bepool_with_nic_config/main.tf
@@ -83,7 +83,7 @@ module "loadbalancer" {
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
   # version = 0.1.4
 
-  enable_telemetry = false # var.enable_telemetry
+  enable_telemetry = var.enable_telemetry
 
   name                = "default-lb"
   location            = azurerm_resource_group.this.location

--- a/examples/bepool_with_nic_config/main.tf
+++ b/examples/bepool_with_nic_config/main.tf
@@ -1,0 +1,150 @@
+terraform {
+  required_version = "~> 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+  }
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.3.0"
+}
+
+# Helps pick a random region from the list of regions.
+resource "random_integer" "region_index" {
+  max = length(local.azure_regions) - 1
+  min = 0
+}
+
+# This is required for resource modules
+
+# Creates a resource group
+resource "azurerm_resource_group" "this" {
+  location = local.azure_regions[random_integer.region_index.result]
+  name     = module.naming.resource_group.name_unique
+}
+
+# Creates a virtual network
+resource "azurerm_virtual_network" "example" {
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.virtual_network.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# Creates a subnet
+resource "azurerm_subnet" "example" {
+  address_prefixes     = ["10.1.1.0/26"]
+  name                 = module.naming.subnet.name_unique
+  resource_group_name  = azurerm_virtual_network.example.resource_group_name
+  virtual_network_name = azurerm_virtual_network.example.name
+}
+
+resource "azurerm_network_interface" "example" {
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.network_interface.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "ipconfig1" # -${module.naming.network_interface.name_unique}"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
+  }
+}
+
+# data "azurerm_network_interface" "example" {
+#   name = azurerm_network_interface.example.name
+#   resource_group_name = azurerm_network_interface.example.resource_group_name
+#   depends_on = [ 
+#     azurerm_network_interface.example 
+#   ]
+# }
+
+module "loadbalancer" {
+
+  source = "../../"
+
+  # source = "Azure/avm-res-network-loadbalancer/azurerm"
+  # version = 0.1.4
+
+  enable_telemetry = false # var.enable_telemetry
+
+  name                = "default-lb"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  frontend_ip_configurations = {
+    frontend_configuration_1 = {
+      name = "myFrontend"
+      # Creates a public IP address
+      create_public_ip_address        = true
+      public_ip_address_resource_name = module.naming.public_ip.name_unique
+    }
+  }
+
+  # Virtual Network for Backend Address Pool(s) if using backend addresses
+  # Leave empty if using network interfaces
+  # backend_address_pool_configuration = azurerm_virtual_network.example.id
+
+  # Backend Address Pool(s)
+  backend_address_pools = {
+    pool1 = {
+      name = "myBackendPool"
+    }
+  }
+
+  backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "pool1"
+      ip_configuration_name            = "ipconfig1" # data.azurerm_network_interface.example.ip_configuration[0].name # Might be easier to specify the name of the ip configuration
+      network_interface_resource_id    = azurerm_network_interface.example.id
+    }
+  }
+
+  backend_address_pool_addresses = {
+    # address1 = {
+    #   name = "${azurerm_network_interface.example.name}-ipconfig1" # must be unique if multiple addresses are used
+    #   backend_address_pool_object_name = "pool1"
+    #   ip_address = azurerm_network_interface.example.private_ip_address
+    # }
+  }
+
+  # Health Probe(s)
+  lb_probes = {
+    tcp1 = {
+      name     = "myHealthProbe"
+      protocol = "Tcp"
+    }
+  }
+
+  # Load Balaner rule(s)
+  lb_rules = {
+    http1 = {
+      name                           = "myHTTPRule"
+      frontend_ip_configuration_name = "myFrontend"
+
+      backend_address_pool_object_names = ["pool1"]
+      protocol                          = "Tcp"
+      frontend_port                     = 80
+      backend_port                      = 80
+
+      probe_object_name = "tcp1"
+
+      idle_timeout_in_minutes = 15
+      enable_tcp_reset        = true
+    }
+  }
+
+}

--- a/examples/bepool_with_nic_config/variables.tf
+++ b/examples/bepool_with_nic_config/variables.tf
@@ -1,0 +1,9 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,13 @@
 locals {
+  pip_diagnostic_settings = { for ds in flatten([
+    for fe_k, fe_v in var.frontend_ip_configurations : [
+      for dk, dv in fe_v.diagnostic_settings : {
+        frontend_key       = fe_k
+        ds_key             = dk
+        diagnostic_setting = dv
+      }
+    ]
+  ]) : "${ds.frontend_key}-${ds.ds_key}" => ds }
   pip_role_assignments = { for ra in flatten([
     for fe_k, fe_v in var.frontend_ip_configurations : [
       for rk, rv in fe_v.role_assignments : {
@@ -9,16 +18,4 @@ locals {
     ]
   ]) : "${ra.frontend_key}-${ra.ra_key}" => ra }
   role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
-}
-
-locals {
-  pip_diagnostic_settings = { for ds in flatten([
-    for fe_k, fe_v in var.frontend_ip_configurations : [
-      for dk, dv in fe_v.diagnostic_settings : {
-        frontend_key       = fe_k
-        ds_key             = dk
-        diagnostic_setting = dv
-      }
-    ]
-  ]) : "${ds.frontend_key}-${ds.ds_key}" => ds }
 }

--- a/main.tf
+++ b/main.tf
@@ -51,22 +51,23 @@ resource "azurerm_lb_backend_address_pool_address" "this" {
   ip_address              = each.value.ip_address
   virtual_network_id      = var.backend_address_pool_configuration
 
-  depends_on = [ 
-    azurerm_lb.this, 
-    azurerm_lb_backend_address_pool.this 
+  depends_on = [
+    azurerm_lb.this,
+    azurerm_lb_backend_address_pool.this
   ]
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "this" {
   for_each = { for be_pool_association, be_pool_association_values in var.backend_address_pool_network_interfaces : be_pool_association => be_pool_association_values }
 
-  network_interface_id      = each.value.network_interface_resource_id
-  ip_configuration_name     = each.value.ip_configuration_name
-  backend_address_pool_id   = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_object_name].id
-  depends_on = [ 
-    azurerm_lb.this, 
-    azurerm_lb_backend_address_pool.this 
-  ]  
+  backend_address_pool_id = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_object_name].id
+  ip_configuration_name   = each.value.ip_configuration_name
+  network_interface_id    = each.value.network_interface_resource_id
+
+  depends_on = [
+    azurerm_lb.this,
+    azurerm_lb_backend_address_pool.this
+  ]
 }
 
 resource "azurerm_lb_probe" "this" {

--- a/main.tf
+++ b/main.tf
@@ -44,12 +44,29 @@ resource "azurerm_lb_backend_address_pool" "this" {
 }
 
 resource "azurerm_lb_backend_address_pool_address" "this" {
-  for_each = { for be_pool_address in var.backend_address_pool_addresses : be_pool_address.name => be_pool_address }
+  for_each = { for be_pool_address, be_pool_address_values in var.backend_address_pool_addresses : be_pool_address => be_pool_address_values }
 
   backend_address_pool_id = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_object_name].id
   name                    = each.value.name
   ip_address              = each.value.ip_address
   virtual_network_id      = var.backend_address_pool_configuration
+
+  depends_on = [ 
+    azurerm_lb.this, 
+    azurerm_lb_backend_address_pool.this 
+  ]
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "this" {
+  for_each = { for be_pool_association, be_pool_association_values in var.backend_address_pool_network_interfaces : be_pool_association => be_pool_association_values }
+
+  network_interface_id      = each.value.network_interface_resource_id
+  ip_configuration_name     = each.value.ip_configuration_name
+  backend_address_pool_id   = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_object_name].id
+  depends_on = [ 
+    azurerm_lb.this, 
+    azurerm_lb_backend_address_pool.this 
+  ]  
 }
 
 resource "azurerm_lb_probe" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -145,35 +145,6 @@ variable "resource_group_name" {
   nullable    = false
 }
 
-variable "backend_address_pool_network_interfaces" {
-  type = map(object({
-    backend_address_pool_object_name = optional(string)
-    ip_configuration_name = optional(string)
-    network_interface_resource_id = optional(string)
-  }))
-  default = {
-
-  }
-  description = <<DESCRIPTION
-  A map of objects that associates one or more backend address pool network interfaces
-
-  - `backend_address_pool_object_name`: (Optional) The name of the backend address pool object that this network interface should be associated with
-  - `ip_configuration_name`: (Optional) The name of the IP configuration that this network interface should be associated with
-  - `network_interface_resource_id`: (Optional) The ID of the network interface that should be associated with the backend address pool
-
-  ```terraform
-  backend_address_pool_network_interfaces = {
-    node1 = {
-      backend_address_pool_object_name = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}"
-      ip_configuration_name = "ipconfig1"
-      network_interface_resource_id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
-    }
-  }
-  ```
-  DESCRIPTION
-
-}
-
 variable "backend_address_pool_addresses" {
   type = map(object({
     name                             = optional(string)
@@ -208,6 +179,34 @@ variable "backend_address_pool_configuration" {
   description = <<DESCRIPTION
   String variable that determines the target virtual network for potential backend pools.
   If using network interfaces, leave this variable empty.
+  DESCRIPTION
+}
+
+variable "backend_address_pool_network_interfaces" {
+  type = map(object({
+    backend_address_pool_object_name = optional(string)
+    ip_configuration_name            = optional(string)
+    network_interface_resource_id    = optional(string)
+  }))
+  default = {
+
+  }
+  description = <<DESCRIPTION
+  A map of objects that associates one or more backend address pool network interfaces
+
+  - `backend_address_pool_object_name`: (Optional) The name of the backend address pool object that this network interface should be associated with
+  - `ip_configuration_name`: (Optional) The name of the IP configuration that this network interface should be associated with
+  - `network_interface_resource_id`: (Optional) The ID of the network interface that should be associated with the backend address pool
+
+  ```terraform
+  backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}"
+      ip_configuration_name = "ipconfig1"
+      network_interface_resource_id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
+    }
+  }
+  ```
   DESCRIPTION
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,35 @@ variable "resource_group_name" {
   nullable    = false
 }
 
+variable "backend_address_pool_network_interfaces" {
+  type = map(object({
+    backend_address_pool_object_name = optional(string)
+    ip_configuration_name = optional(string)
+    network_interface_resource_id = optional(string)
+  }))
+  default = {
+
+  }
+  description = <<DESCRIPTION
+  A map of objects that associates one or more backend address pool network interfaces
+
+  - `backend_address_pool_object_name`: (Optional) The name of the backend address pool object that this network interface should be associated with
+  - `ip_configuration_name`: (Optional) The name of the IP configuration that this network interface should be associated with
+  - `network_interface_resource_id`: (Optional) The ID of the network interface that should be associated with the backend address pool
+
+  ```terraform
+  backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}"
+      ip_configuration_name = "ipconfig1"
+      network_interface_resource_id = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
+    }
+  }
+  ```
+  DESCRIPTION
+
+}
+
 variable "backend_address_pool_addresses" {
   type = map(object({
     name                             = optional(string)
@@ -178,6 +207,7 @@ variable "backend_address_pool_configuration" {
   default     = null
   description = <<DESCRIPTION
   String variable that determines the target virtual network for potential backend pools.
+  If using network interfaces, leave this variable empty.
   DESCRIPTION
 }
 


### PR DESCRIPTION
* new example for add to backend pool by ip addresses
* new example for add to backend pool by nic configuration

NOTE: modifying backend pool with ip configuration requires a re-apply even if terraform shows remaining backend pool ip addresses still exist in state - for some reason, they are removing in Azure, please see [here](https://github.com/hashicorp/terraform-provider-azurerm/issues/10496)