### PR TITLE
Multi bepool config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ map(object({
     name                             = optional(string)
     backend_address_pool_object_name = optional(string)
     ip_address                       = optional(string)
+    virtual_network_resource_id      = optional(string)
   }))
 ```
 
@@ -290,7 +291,8 @@ Type:
 
 ```hcl
 map(object({
-    name = optional(string, "bepool-1")
+    name                        = optional(string, "bepool-1")
+    virtual_network_resource_id = optional(string)
     tunnel_interfaces = optional(map(object({
       identifier = optional(number)
       type       = optional(string)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Description:   A map of backend address pool addresses to associate with the bac
   - `name`: (Optional) The name of the backend address pool address, if adding an address. Changing this forces a new backend address pool address to be created.
   - `backend_address_pool_object_name`: (Optional) The name of the backend address pool object within the virtual network. Changing this forces a new backend address pool address to be created.
   - `ip_address`: (Optional) The static IP address which should be allocated to the backend address pool.
+  - `virtual_network_resource_id`: (Optional) The ID of the virtual network that the backend address pool address should be associated with. Helps with mapping to correct backend pool.
 
   ```terraform
   backend_address_pool_addresses = {
@@ -217,7 +218,8 @@ Default: `{}`
 
 ### <a name="input_backend_address_pool_configuration"></a> [backend\_address\_pool\_configuration](#input\_backend\_address\_pool\_configuration)
 
-Description:   String variable that determines the target virtual network for potential backend pools.  
+Description:   String variable that determines the target virtual network for potential backend pools, at the load balancer level.  
+  You can specify the `virutal_network_resource_id` at the pool level or backend address level.  
   If using network interfaces, leave this variable empty.
 
 Type: `string`
@@ -259,6 +261,7 @@ Default: `{}`
 Description:   A map of objects that creates one or more backend pools
 
   - `name`: (Optional) The name of the backend address pool to create
+  - `virtual_network_resource_id`: (Optional) The ID of the virtual network that the backend pool should be associated with. Sets pool to use only backend addresses via private IP. Leave empty if using network interfaces or mix of network interfaces and backend addresses.
   - `tunnel_interfaces`: (Optional) A map of objects that creates one or more tunnel interfaces for the backend pool
     - `identifier`: (Optional) The identifier of the tunnel interface
     - `type`: (Optional) The type of the tunnel interface
@@ -806,9 +809,29 @@ The following outputs are exported:
 
 Description: Outputs the entire Azure Load Balancer resource
 
+### <a name="output_azurerm_lb_backend_address_pool"></a> [azurerm\_lb\_backend\_address\_pool](#output\_azurerm\_lb\_backend\_address\_pool)
+
+Description: Outputs each backend address pool in its entirety
+
+### <a name="output_azurerm_lb_nat_rule"></a> [azurerm\_lb\_nat\_rule](#output\_azurerm\_lb\_nat\_rule)
+
+Description: Outputs each NAT rule in its entirety
+
 ### <a name="output_azurerm_public_ip"></a> [azurerm\_public\_ip](#output\_azurerm\_public\_ip)
 
-Description: Outputs each Public IP Address resource in it's entirety
+Description: Outputs each Public IP Address resource in its entirety
+
+### <a name="output_name"></a> [name](#output\_name)
+
+Description: Outputs the entire Azure Load Balancer resource
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: Outputs the entire Azure Load Balancer resource
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: Outputs the entire Azure Load Balancer resource
 
 ## Modules
 

--- a/examples/bepool/README.md
+++ b/examples/bepool/README.md
@@ -1,11 +1,9 @@
 <!-- BEGIN_TF_DOCS -->
-# Internal Load Balancer \ Standard SKU example
+# Default example
 
-This deploys the module as a common internal load balancer quick start.
+This deploys the module as a Standard SKU Public Load Balancer with two backend pools: one configured to use private IPs and one configured to use network interfaces (ip configurations).
 
 ```hcl
-# THIS IS CURRENTLY WORKING
-
 terraform {
   required_version = "~> 1.5"
   required_providers {
@@ -30,18 +28,21 @@ module "naming" {
   version = "0.3.0"
 }
 
-# This picks a random region from the list of regions.
+# Helps pick a random region from the list of regions.
 resource "random_integer" "region_index" {
   max = length(local.azure_regions) - 1
   min = 0
 }
 
 # This is required for resource modules
+
+# Creates a resource group
 resource "azurerm_resource_group" "this" {
   location = local.azure_regions[random_integer.region_index.result]
   name     = module.naming.resource_group.name_unique
 }
 
+# Creates a virtual network
 resource "azurerm_virtual_network" "example" {
   address_space       = ["10.1.0.0/16"]
   location            = azurerm_resource_group.this.location
@@ -49,11 +50,36 @@ resource "azurerm_virtual_network" "example" {
   resource_group_name = azurerm_resource_group.this.name
 }
 
+# Creates a subnet
 resource "azurerm_subnet" "example" {
   address_prefixes     = ["10.1.1.0/26"]
   name                 = module.naming.subnet.name_unique
   resource_group_name  = azurerm_virtual_network.example.resource_group_name
   virtual_network_name = azurerm_virtual_network.example.name
+}
+
+resource "azurerm_network_interface" "example_1" {
+  location            = azurerm_resource_group.this.location
+  name                = "${module.naming.network_interface.name_unique}-1"
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "ipconfig1"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
+  }
+}
+
+resource "azurerm_network_interface" "example_2" {
+  location            = azurerm_resource_group.this.location
+  name                = "${module.naming.network_interface.name_unique}-2"
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "ipconfig1"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
+  }
 }
 
 module "loadbalancer" {
@@ -65,30 +91,55 @@ module "loadbalancer" {
 
   enable_telemetry = var.enable_telemetry
 
-  name                = "internal-lb"
+  name                = "bepool-lb"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
-  # Virtual Network and Subnet for Internal LoadBalancer
-  # frontend_vnet_resource_id   = azurerm_virtual_network.example.id
-  frontend_subnet_resource_id = azurerm_subnet.example.id
-
-  # Frontend IP Configuration
   frontend_ip_configurations = {
     frontend_configuration_1 = {
       name = "myFrontend"
+      # Creates a public IP address
+      create_public_ip_address        = true
+      public_ip_address_resource_name = module.naming.public_ip.name_unique
     }
   }
 
-  # Backend Address Pool
+  /*
+  # Virtual Network for Backend Address Pool(s) if using backend addresses
+  # Use if using only backend addresses via private IPs in all pools
+  # Leave empty if using backend pools with network interfaces or backend pools with a mix of network interfaces and backend addresses
+  backend_address_pool_configuration = azurerm_virtual_network.example.id
+  */
+
+  # Backend Address Pool(s)
   backend_address_pools = {
     pool1 = {
-      name = "myBackendPool"
+      name                        = "primaryPool"
+      virtual_network_resource_id = azurerm_virtual_network.example.id # set a virtual_network_resource_id if using backend_address_pool_addresses
+    }
+    pool2 = {
+      name = "secondaryPool"
+
     }
   }
 
-  # Virtual Network for Backend Address Pool(s)
-  backend_address_pool_configuration = azurerm_virtual_network.example.id
+  backend_address_pool_addresses = {
+    address1 = {
+      name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_1.private_ip_address
+      virtual_network_resource_id      = azurerm_virtual_network.example.id
+    }
+  }
+
+  backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "pool2"
+      ip_configuration_name            = "ipconfig1"
+      network_interface_resource_id    = azurerm_network_interface.example_2.id
+    }
+
+  }
 
   # Health Probe(s)
   lb_probes = {
@@ -104,7 +155,7 @@ module "loadbalancer" {
       name                           = "myHTTPRule"
       frontend_ip_configuration_name = "myFrontend"
 
-      backend_address_pool_object_names = ["pool1"]
+      backend_address_pool_object_names = ["pool1", "pool2"]
       protocol                          = "Tcp"
       frontend_port                     = 80
       backend_port                      = 80
@@ -116,12 +167,13 @@ module "loadbalancer" {
     }
   }
 
-}
+  depends_on = [
+    # To ensure that the backend address pool is created before the network interfaces' ip addresses are associated
+    azurerm_network_interface.example_1,
+    azurerm_network_interface.example_2
+  ]
 
-# output "azurerm_lb" {
-#   value       = module.loadbalancer.azurerm_lb
-#   description = "Outputs the entire Azure Load Balancer resource"
-# }
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -147,6 +199,8 @@ The following providers are used by this module:
 
 The following resources are used by this module:
 
+- [azurerm_network_interface.example_1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
+- [azurerm_network_interface.example_2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [azurerm_subnet.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) (resource)
 - [azurerm_virtual_network.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) (resource)
@@ -173,7 +227,19 @@ Default: `true`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_azurerm_lb_backend_address_pool"></a> [azurerm\_lb\_backend\_address\_pool](#output\_azurerm\_lb\_backend\_address\_pool)
+
+Description: Outputs each backend address pool
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: Outputs the entire Azure Load Balancer resource
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: Outputs the entire Azure Load Balancer resource
 
 ## Modules
 

--- a/examples/bepool/README.md
+++ b/examples/bepool/README.md
@@ -152,13 +152,27 @@ module "loadbalancer" {
   # Load Balaner rule(s)
   lb_rules = {
     http1 = {
-      name                           = "myHTTPRule"
+      name                           = "primaryRule"
       frontend_ip_configuration_name = "myFrontend"
 
-      backend_address_pool_object_names = ["pool1", "pool2"]
+      backend_address_pool_object_names = ["pool1"]
       protocol                          = "Tcp"
       frontend_port                     = 80
       backend_port                      = 80
+
+      probe_object_name = "tcp1"
+
+      idle_timeout_in_minutes = 15
+      enable_tcp_reset        = true
+    }
+    http2 = {
+      name                           = "secondaryRule"
+      frontend_ip_configuration_name = "myFrontend"
+
+      backend_address_pool_object_names = ["pool2"]
+      protocol                          = "Tcp"
+      frontend_port                     = 81
+      backend_port                      = 81
 
       probe_object_name = "tcp1"
 

--- a/examples/bepool/_footer.md
+++ b/examples/bepool/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/bepool/_header.md
+++ b/examples/bepool/_header.md
@@ -1,0 +1,3 @@
+# Default example
+
+This deploys the module as a Standard SKU Public Load Balancer with two backend pools: one configured to use private IPs and one configured to use network interfaces (ip configurations).

--- a/examples/bepool/locals.tf
+++ b/examples/bepool/locals.tf
@@ -1,0 +1,16 @@
+# We pick a random region from this list.
+locals {
+  azure_regions = [
+    "westeurope",
+    "northeurope",
+    "eastus",
+    "eastus2",
+    "westus",
+    "westus2",
+    "southcentralus",
+    "northcentralus",
+    "centralus",
+    "eastasia",
+    "southeastasia",
+  ]
+}

--- a/examples/bepool/main.tf
+++ b/examples/bepool/main.tf
@@ -146,13 +146,27 @@ module "loadbalancer" {
   # Load Balaner rule(s)
   lb_rules = {
     http1 = {
-      name                           = "myHTTPRule"
+      name                           = "primaryRule"
       frontend_ip_configuration_name = "myFrontend"
 
-      backend_address_pool_object_names = ["pool1", "pool2"]
+      backend_address_pool_object_names = ["pool1"]
       protocol                          = "Tcp"
       frontend_port                     = 80
       backend_port                      = 80
+
+      probe_object_name = "tcp1"
+
+      idle_timeout_in_minutes = 15
+      enable_tcp_reset        = true
+    }
+    http2 = {
+      name                           = "secondaryRule"
+      frontend_ip_configuration_name = "myFrontend"
+
+      backend_address_pool_object_names = ["pool2"]
+      protocol                          = "Tcp"
+      frontend_port                     = 81
+      backend_port                      = 81
 
       probe_object_name = "tcp1"
 

--- a/examples/bepool/main.tf
+++ b/examples/bepool/main.tf
@@ -85,7 +85,7 @@ module "loadbalancer" {
 
   enable_telemetry = var.enable_telemetry
 
-  name                = "default-lb"
+  name                = "bepool-lb"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 
@@ -100,8 +100,8 @@ module "loadbalancer" {
 
   /*
   # Virtual Network for Backend Address Pool(s) if using backend addresses
-  # Use if using only backend addresses via private IP
-  # Leave empty if using network interfaces or mix of network interfaces and backend addresses
+  # Use if using only backend addresses via private IPs in all pools
+  # Leave empty if using backend pools with network interfaces or backend pools with a mix of network interfaces and backend addresses
   backend_address_pool_configuration = azurerm_virtual_network.example.id
   */
 
@@ -109,11 +109,20 @@ module "loadbalancer" {
   backend_address_pools = {
     pool1 = {
       name                        = "primaryPool"
-      virtual_network_resource_id = azurerm_virtual_network.example.id
+      virtual_network_resource_id = azurerm_virtual_network.example.id # set a virtual_network_resource_id if using backend_address_pool_addresses
     }
     pool2 = {
       name = "secondaryPool"
 
+    }
+  }
+
+  backend_address_pool_addresses = {
+    address1 = {
+      name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_1.private_ip_address
+      virtual_network_resource_id      = azurerm_virtual_network.example.id
     }
   }
 
@@ -124,20 +133,6 @@ module "loadbalancer" {
       network_interface_resource_id    = azurerm_network_interface.example_2.id
     }
 
-  }
-
-  backend_address_pool_addresses = {
-    address1 = {
-      name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
-      backend_address_pool_object_name = "pool1"
-      ip_address                       = azurerm_network_interface.example_1.private_ip_address
-      virtual_network_resource_id      = azurerm_virtual_network.example.id
-    }
-    # address2 = {
-    #   name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address                       = azurerm_network_interface.example_2.private_ip_address
-    # }
   }
 
   # Health Probe(s)
@@ -154,7 +149,7 @@ module "loadbalancer" {
       name                           = "myHTTPRule"
       frontend_ip_configuration_name = "myFrontend"
 
-      backend_address_pool_object_names = ["pool1"]
+      backend_address_pool_object_names = ["pool1", "pool2"]
       protocol                          = "Tcp"
       frontend_port                     = 80
       backend_port                      = 80

--- a/examples/bepool/outputs.tf
+++ b/examples/bepool/outputs.tf
@@ -1,0 +1,14 @@
+output "azurerm_lb_backend_address_pool" {
+  description = "Outputs each backend address pool"
+  value       = module.loadbalancer.azurerm_lb_backend_address_pool
+}
+
+output "resource" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = module.loadbalancer.resource
+}
+
+output "resource_id" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = module.loadbalancer.resource_id
+}

--- a/examples/bepool/variables.tf
+++ b/examples/bepool/variables.tf
@@ -1,0 +1,9 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}

--- a/examples/bepool_with_ip_address/README.md
+++ b/examples/bepool_with_ip_address/README.md
@@ -104,12 +104,12 @@ module "loadbalancer" {
     }
   }
 
-  /*
+  # /*
   # Virtual Network for Backend Address Pool(s) if using backend addresses
   # Use if using only backend addresses via private IP
   # Leave empty if using network interfaces or mix of network interfaces and backend addresses
   backend_address_pool_configuration = azurerm_virtual_network.example.id
-  */
+  # */
 
   # Backend Address Pool(s)
   backend_address_pools = {
@@ -117,19 +117,6 @@ module "loadbalancer" {
       name                        = "primaryPool"
       virtual_network_resource_id = azurerm_virtual_network.example.id
     }
-    pool2 = {
-      name = "secondaryPool"
-
-    }
-  }
-
-  backend_address_pool_network_interfaces = {
-    node1 = {
-      backend_address_pool_object_name = "pool2"
-      ip_configuration_name            = "ipconfig1"
-      network_interface_resource_id    = azurerm_network_interface.example_2.id
-    }
-
   }
 
   backend_address_pool_addresses = {
@@ -137,13 +124,19 @@ module "loadbalancer" {
       name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
       backend_address_pool_object_name = "pool1"
       ip_address                       = azurerm_network_interface.example_1.private_ip_address
-      virtual_network_resource_id      = azurerm_virtual_network.example.id
+      # virtual_network_resource_id      = azurerm_virtual_network.example.id
     }
-    # address2 = {
-    #   name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address                       = azurerm_network_interface.example_2.private_ip_address
-    # }
+    address2 = {
+      name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_2.private_ip_address
+      # virtual_network_resource_id      = azurerm_virtual_network.example.id
+
+    }
+  }
+
+  backend_address_pool_network_interfaces = {
+
   }
 
   # Health Probe(s)

--- a/examples/bepool_with_ip_address/README.md
+++ b/examples/bepool_with_ip_address/README.md
@@ -87,7 +87,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 
@@ -104,18 +104,31 @@ module "loadbalancer" {
     }
   }
 
+  /*
   # Virtual Network for Backend Address Pool(s) if using backend addresses
-  # Leave empty if using network interfaces
+  # Use if using only backend addresses via private IP
+  # Leave empty if using network interfaces or mix of network interfaces and backend addresses
   backend_address_pool_configuration = azurerm_virtual_network.example.id
+  */
 
   # Backend Address Pool(s)
   backend_address_pools = {
     pool1 = {
-      name = "myBackendPool"
+      name                        = "primaryPool"
+      virtual_network_resource_id = azurerm_virtual_network.example.id
+    }
+    pool2 = {
+      name = "secondaryPool"
+
     }
   }
 
   backend_address_pool_network_interfaces = {
+    node1 = {
+      backend_address_pool_object_name = "pool2"
+      ip_configuration_name            = "ipconfig1"
+      network_interface_resource_id    = azurerm_network_interface.example_2.id
+    }
 
   }
 
@@ -124,12 +137,13 @@ module "loadbalancer" {
       name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
       backend_address_pool_object_name = "pool1"
       ip_address                       = azurerm_network_interface.example_1.private_ip_address
+      virtual_network_resource_id      = azurerm_virtual_network.example.id
     }
-    address2 = {
-      name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
-      backend_address_pool_object_name = "pool1"
-      ip_address                       = azurerm_network_interface.example_2.private_ip_address
-    }
+    # address2 = {
+    #   name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
+    #   backend_address_pool_object_name = "pool1"
+    #   ip_address                       = azurerm_network_interface.example_2.private_ip_address
+    # }
   }
 
   # Health Probe(s)
@@ -218,7 +232,19 @@ Default: `true`
 
 ## Outputs
 
-No outputs.
+The following outputs are exported:
+
+### <a name="output_azurerm_lb_backend_address_pool"></a> [azurerm\_lb\_backend\_address\_pool](#output\_azurerm\_lb\_backend\_address\_pool)
+
+Description: Outputs each backend address pool
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: Outputs the entire Azure Load Balancer resource
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: Outputs the entire Azure Load Balancer resource
 
 ## Modules
 

--- a/examples/bepool_with_ip_address/main.tf
+++ b/examples/bepool_with_ip_address/main.tf
@@ -98,12 +98,12 @@ module "loadbalancer" {
     }
   }
 
-  /*
+  # /*
   # Virtual Network for Backend Address Pool(s) if using backend addresses
   # Use if using only backend addresses via private IP
   # Leave empty if using network interfaces or mix of network interfaces and backend addresses
   backend_address_pool_configuration = azurerm_virtual_network.example.id
-  */
+  # */
 
   # Backend Address Pool(s)
   backend_address_pools = {
@@ -111,19 +111,6 @@ module "loadbalancer" {
       name                        = "primaryPool"
       virtual_network_resource_id = azurerm_virtual_network.example.id
     }
-    pool2 = {
-      name = "secondaryPool"
-
-    }
-  }
-
-  backend_address_pool_network_interfaces = {
-    node1 = {
-      backend_address_pool_object_name = "pool2"
-      ip_configuration_name            = "ipconfig1"
-      network_interface_resource_id    = azurerm_network_interface.example_2.id
-    }
-
   }
 
   backend_address_pool_addresses = {
@@ -131,13 +118,19 @@ module "loadbalancer" {
       name                             = "${azurerm_network_interface.example_1.name}-ipconfig1" # must be unique if multiple addresses are used
       backend_address_pool_object_name = "pool1"
       ip_address                       = azurerm_network_interface.example_1.private_ip_address
-      virtual_network_resource_id      = azurerm_virtual_network.example.id
+      # virtual_network_resource_id      = azurerm_virtual_network.example.id
     }
-    # address2 = {
-    #   name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
-    #   backend_address_pool_object_name = "pool1"
-    #   ip_address                       = azurerm_network_interface.example_2.private_ip_address
-    # }
+    address2 = {
+      name                             = "${azurerm_network_interface.example_2.name}-ipconfig1" # must be unique if multiple addresses are used
+      backend_address_pool_object_name = "pool1"
+      ip_address                       = azurerm_network_interface.example_2.private_ip_address
+      # virtual_network_resource_id      = azurerm_virtual_network.example.id
+
+    }
+  }
+
+  backend_address_pool_network_interfaces = {
+
   }
 
   # Health Probe(s)

--- a/examples/bepool_with_ip_address/outputs.tf
+++ b/examples/bepool_with_ip_address/outputs.tf
@@ -1,0 +1,14 @@
+output "azurerm_lb_backend_address_pool" {
+  description = "Outputs each backend address pool"
+  value       = module.loadbalancer.azurerm_lb_backend_address_pool
+}
+
+output "resource" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = module.loadbalancer.resource
+}
+
+output "resource_id" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = module.loadbalancer.resource_id
+}

--- a/examples/bepool_with_nic_config/README.md
+++ b/examples/bepool_with_nic_config/README.md
@@ -87,7 +87,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/bepool_with_nic_config/main.tf
+++ b/examples/bepool_with_nic_config/main.tf
@@ -81,7 +81,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -66,7 +66,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -60,7 +60,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/gateway/README.md
+++ b/examples/gateway/README.md
@@ -147,7 +147,7 @@ module "gateway_loadbalancer" {
   source = "../.."
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/gateway/main.tf
+++ b/examples/gateway/main.tf
@@ -141,7 +141,7 @@ module "gateway_loadbalancer" {
   source = "../.."
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/interfaces/README.md
+++ b/examples/interfaces/README.md
@@ -76,7 +76,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/interfaces/main.tf
+++ b/examples/interfaces/main.tf
@@ -70,7 +70,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/internal/main.tf
+++ b/examples/internal/main.tf
@@ -55,7 +55,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/public/README.md
+++ b/examples/public/README.md
@@ -62,7 +62,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -56,7 +56,7 @@ module "loadbalancer" {
   source = "../../"
 
   # source = "Azure/avm-res-network-loadbalancer/azurerm"
-  # version = "0.1.6"
+  # version = "0.1.7"
 
   enable_telemetry = var.enable_telemetry
 

--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,5 +1,5 @@
 {
   "locals": {
-    "module_version": "0.1.6"
+    "module_version": "0.1.7"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_lb_backend_address_pool" "this" {
 
   loadbalancer_id    = azurerm_lb.this.id
   name               = each.value.name
-  virtual_network_id = var.backend_address_pool_configuration
+  virtual_network_id = coalesce(each.value.virtual_network_resource_id, var.backend_address_pool_configuration)
 
   dynamic "tunnel_interface" {
     for_each = each.value.tunnel_interfaces
@@ -49,7 +49,7 @@ resource "azurerm_lb_backend_address_pool_address" "this" {
   backend_address_pool_id = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_object_name].id
   name                    = each.value.name
   ip_address              = each.value.ip_address
-  virtual_network_id      = var.backend_address_pool_configuration
+  virtual_network_id      = coalesce(each.value.virtual_network_resource_id, var.backend_address_pool_configuration)
 
   depends_on = [
     azurerm_lb.this,

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_lb_backend_address_pool" "this" {
 
   loadbalancer_id    = azurerm_lb.this.id
   name               = each.value.name
-  virtual_network_id = coalesce(each.value.virtual_network_resource_id, var.backend_address_pool_configuration)
+  virtual_network_id = (each.value.virtual_network_resource_id != null || var.backend_address_pool_configuration != null) ? coalesce(each.value.virtual_network_resource_id, var.backend_address_pool_configuration) : null
 
   dynamic "tunnel_interface" {
     for_each = each.value.tunnel_interfaces
@@ -49,7 +49,7 @@ resource "azurerm_lb_backend_address_pool_address" "this" {
   backend_address_pool_id = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_object_name].id
   name                    = each.value.name
   ip_address              = each.value.ip_address
-  virtual_network_id      = coalesce(each.value.virtual_network_resource_id, var.backend_address_pool_configuration)
+  virtual_network_id      = (each.value.virtual_network_resource_id != null || var.backend_address_pool_configuration != null) ? coalesce(each.value.virtual_network_resource_id, var.backend_address_pool_configuration) : null
 
   depends_on = [
     azurerm_lb.this,

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,32 @@ output "azurerm_lb" {
   value       = azurerm_lb.this
 }
 
+output "azurerm_lb_backend_address_pool" {
+  description = "Outputs each backend address pool in its entirety"
+  value       = azurerm_lb_backend_address_pool.this
+}
+
+output "azurerm_lb_nat_rule" {
+  description = "Outputs each NAT rule in its entirety"
+  value       = azurerm_lb_nat_rule.this
+}
+
 output "azurerm_public_ip" {
-  description = "Outputs each Public IP Address resource in it's entirety"
+  description = "Outputs each Public IP Address resource in its entirety"
   value       = azurerm_public_ip.this
+}
+
+output "name" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = azurerm_lb.this.name
+}
+
+output "resource" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = azurerm_lb.this
+}
+
+output "resource_id" {
+  description = "Outputs the entire Azure Load Balancer resource"
+  value       = azurerm_lb.this.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,7 @@ variable "backend_address_pool_addresses" {
     name                             = optional(string)
     backend_address_pool_object_name = optional(string)
     ip_address                       = optional(string)
+    virtual_network_resource_id      = optional(string)
   }))
   default = {
 
@@ -212,7 +213,8 @@ variable "backend_address_pool_network_interfaces" {
 
 variable "backend_address_pools" {
   type = map(object({
-    name = optional(string, "bepool-1")
+    name                        = optional(string, "bepool-1")
+    virtual_network_resource_id = optional(string)
     tunnel_interfaces = optional(map(object({
       identifier = optional(number)
       type       = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,7 @@ variable "backend_address_pool_addresses" {
   - `name`: (Optional) The name of the backend address pool address, if adding an address. Changing this forces a new backend address pool address to be created.
   - `backend_address_pool_object_name`: (Optional) The name of the backend address pool object within the virtual network. Changing this forces a new backend address pool address to be created.
   - `ip_address`: (Optional) The static IP address which should be allocated to the backend address pool.
+  - `virtual_network_resource_id`: (Optional) The ID of the virtual network that the backend address pool address should be associated with. Helps with mapping to correct backend pool.
 
   ```terraform
   backend_address_pool_addresses = {
@@ -178,7 +179,8 @@ variable "backend_address_pool_configuration" {
   type        = string
   default     = null
   description = <<DESCRIPTION
-  String variable that determines the target virtual network for potential backend pools.
+  String variable that determines the target virtual network for potential backend pools, at the load balancer level.
+  You can specify the `virutal_network_resource_id` at the pool level or backend address level.
   If using network interfaces, leave this variable empty.
   DESCRIPTION
 }
@@ -229,6 +231,7 @@ variable "backend_address_pools" {
   A map of objects that creates one or more backend pools
 
   - `name`: (Optional) The name of the backend address pool to create
+  - `virtual_network_resource_id`: (Optional) The ID of the virtual network that the backend pool should be associated with. Sets pool to use only backend addresses via private IP. Leave empty if using network interfaces or mix of network interfaces and backend addresses.
   - `tunnel_interfaces`: (Optional) A map of objects that creates one or more tunnel interfaces for the backend pool
     - `identifier`: (Optional) The identifier of the tunnel interface
     - `type`: (Optional) The type of the tunnel interface


### PR DESCRIPTION
## Description

- new additions / syntax fixes for outputs
- new example showing mix backend pools configuration
- non-breaking change for configuring `virtual_network_id` via `virtual_network_resource_id` or `backend_address_pool_configuration` instead of being set to `backend_address_pool_configuration` only

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks
