### PR TITLE
modified lb_rules idle_timeout_in_minutes max value to 100

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -688,8 +688,8 @@ variable "lb_rules" {
   validation {
     condition = length([for obj in var.lb_rules :
       true
-    if obj.idle_timeout_in_minutes >= 4 && obj.idle_timeout_in_minutes <= 30]) == length(var.lb_rules)
-    error_message = "The value for `idle_timeout_in_minutes` must be between 4 and 30"
+    if obj.idle_timeout_in_minutes >= 4 && obj.idle_timeout_in_minutes <= 100]) == length(var.lb_rules)
+    error_message = "The value for `idle_timeout_in_minutes` must be between 4 and 100"
   }
   validation {
     condition = length([for obj in var.lb_rules :


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->
lb_rules input for the loadbalancer has a property called "idle_timeout_in_minutes" which currently accepts min value of 4 and max value of 30. But, Azure allows a max value of 100. Hence fixed the variable validation.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
